### PR TITLE
[2024.07.16] postTheme: 태블릿, 모바일 미디어쿼리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@tailwindcss/aspect-ratio": "^0.4.2",
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.39",
         "postcss-loader": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "@tailwindcss/aspect-ratio": "^0.4.2",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "postcss-loader": "^8.1.1",

--- a/src/pages/postTheme/PostTheme.tsx
+++ b/src/pages/postTheme/PostTheme.tsx
@@ -15,19 +15,21 @@ const PostTheme: React.FC = () => {
   } = useThemeContext();
 
   return (
-    <Form
-      handleChange={handleChange}
-      themeData={themeData}
-      isButtonDisabled={isButtonDisabled}
-      handleButtonClick={handleButtonClick}
-      setThemeData={setThemeData}
-    >
-      <ReceiverInput handleChange={handleChange} themeData={themeData} />
-      <ThemeSelection
-        setIsButtonDisabled={setIsButtonDisabled}
+    <main className="flex justify-center ">
+      <Form
+        handleChange={handleChange}
+        themeData={themeData}
+        isButtonDisabled={isButtonDisabled}
+        handleButtonClick={handleButtonClick}
         setThemeData={setThemeData}
-      />
-    </Form>
+      >
+        <ReceiverInput handleChange={handleChange} themeData={themeData} />
+        <ThemeSelection
+          setIsButtonDisabled={setIsButtonDisabled}
+          setThemeData={setThemeData}
+        />
+      </Form>
+    </main>
   );
 };
 

--- a/src/pages/postTheme/components/BackgroundColorList.tsx
+++ b/src/pages/postTheme/components/BackgroundColorList.tsx
@@ -27,24 +27,29 @@ export const BackgroundColorList: React.FC<BackgroundColorListProps> = ({
   }
 
   return (
-    <menu className="flex gap-x-4 max-md:grid grid-cols-2 gap-y-4">
+    <menu className="flex gap-x-4 max-md:grid max-md:grid-cols-2 max-md:gap-y-4 max-md:mb-16 max-[1248px]:mb-60">
       {backgroundColors.map((color, index) => (
-        <div key={`${color}-${index}`} className="relative flex-1">
+        <div
+          key={`${color}-${index}`}
+          className="relative flex-1 max-md:aspect-w-1 max-md:aspect-h-1"
+        >
           <input
             name="backgroundColor"
             type="button"
             value={color}
             onClick={() => handleOptionClick("backgroundColor", color)}
-            className={`w-full h-[154px] rounded-2xl outline outline-1 outline-gray-300 text-transparent cursor-pointer ${getColorClass(
+            className={`relative w-full h-[168px] rounded-2xl outline outline-1 outline-gray-300 text-transparent cursor-pointer ${getColorClass(
               color
             )}`}
           />
           {selectedColor === color && (
-            <img
-              src={IcCheckTheme}
-              alt="배경화면 선택 아이콘"
-              className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12"
-            />
+            <div className="absolute top-0 w-full h-full rounded-2xl">
+              <img
+                src={IcCheckTheme}
+                alt="배경화면 선택 아이콘"
+                className="absolute  top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12"
+              />
+            </div>
           )}
         </div>
       ))}

--- a/src/pages/postTheme/components/BackgroundColorList.tsx
+++ b/src/pages/postTheme/components/BackgroundColorList.tsx
@@ -27,9 +27,9 @@ export const BackgroundColorList: React.FC<BackgroundColorListProps> = ({
   }
 
   return (
-    <menu className="flex gap-x-4 max-md:grid max-md:grid-cols-2 max-md:gap-y-4 max-md:mb-16 max-[1248px]:mb-60">
+    <ul className="flex gap-x-4 max-md:grid max-md:grid-cols-2 max-md:gap-y-4 max-md:mb-16 max-[1248px]:mb-60">
       {backgroundColors.map((color, index) => (
-        <div
+        <li
           key={`${color}-${index}`}
           className="relative flex-1 max-md:aspect-w-1 max-md:aspect-h-1"
         >
@@ -51,8 +51,8 @@ export const BackgroundColorList: React.FC<BackgroundColorListProps> = ({
               />
             </div>
           )}
-        </div>
+        </li>
       ))}
-    </menu>
+    </ul>
   );
 };

--- a/src/pages/postTheme/components/BackgroundColorList.tsx
+++ b/src/pages/postTheme/components/BackgroundColorList.tsx
@@ -27,7 +27,7 @@ export const BackgroundColorList: React.FC<BackgroundColorListProps> = ({
   }
 
   return (
-    <menu className="flex gap-x-4">
+    <menu className="flex gap-x-4 max-md:grid grid-cols-2 gap-y-4">
       {backgroundColors.map((color, index) => (
         <div key={`${color}-${index}`} className="relative flex-1">
           <input
@@ -35,7 +35,7 @@ export const BackgroundColorList: React.FC<BackgroundColorListProps> = ({
             type="button"
             value={color}
             onClick={() => handleOptionClick("backgroundColor", color)}
-            className={`w-full h-[168px] rounded-2xl outline outline-1 outline-gray-300 text-transparent cursor-pointer ${getColorClass(
+            className={`w-full h-[154px] rounded-2xl outline outline-1 outline-gray-300 text-transparent cursor-pointer ${getColorClass(
               color
             )}`}
           />

--- a/src/pages/postTheme/components/BackgroundImageList.tsx
+++ b/src/pages/postTheme/components/BackgroundImageList.tsx
@@ -52,31 +52,30 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
     <div>
       <ul className="flex gap-x-4">
         {imageUrls.map((imageUrl, index) => (
-          <li key={index} className="relative">
+          <li key={index} className="relative w-full h-[168px] rounded-2xl">
             <input
               type="checkbox"
-              id={`checkbox-${index}`}
+              id={`img-${index}`}
               name="backgroundImageURL"
               value={imageUrl}
               checked={selectedImageUrl === imageUrl}
               onChange={() => handleImageSelect(imageUrl)}
               className="hidden"
             />
-            <label
-              htmlFor={`checkbox-${index}`}
-              className="block w-[168px] h-[168px] rounded-2xl cursor-pointer relative"
-            >
+            <label htmlFor={`img-${index}`} className="cursor-pointer">
               <img
                 src={imageUrl}
                 alt={`background ${index}`}
-                className="absolute top-0 w-full h-full rounded-2xl"
+                className="absolute top-0 w-full h-full object-cover rounded-2xl"
               />
               {selectedImageUrl === imageUrl && (
-                <img
-                  src={IcCheckTheme}
-                  alt="배경화면 선택 아이콘"
-                  className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12"
-                />
+                <div className="relative w-full h-[168px] rounded-2xl bg-white bg-opacity-60">
+                  <img
+                    src={IcCheckTheme}
+                    alt="배경화면 선택 아이콘"
+                    className="absolute  top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12"
+                  />
+                </div>
               )}
             </label>
           </li>

--- a/src/pages/postTheme/components/BackgroundImageList.tsx
+++ b/src/pages/postTheme/components/BackgroundImageList.tsx
@@ -49,12 +49,15 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
   };
 
   return (
-    <div className="max-md:grid">
-      <ul className="flex gap-x-4 max-md:grid grid-cols-2 row-span-2 gap-y-4">
+    <>
+      <ul
+        className="flex grow gap-x-4 h-[168px] max-md:grid max-md:grid-cols-2 max-md:gap-y-4 max-md:h-full max-md:mb-16
+      max-[1248px]:mb-60"
+      >
         {imageUrls.map((imageUrl, index) => (
           <li
             key={index}
-            className="relative w-full h-[154px] rounded-2xl max-md:grid"
+            className="relative w-full rounded-2xl max-md:grid max-md:aspect-w-1 max-md:aspect-h-1"
           >
             <input
               type="checkbox"
@@ -69,10 +72,11 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
               <img
                 src={imageUrl}
                 alt={`background ${index}`}
-                className="absolute top-0 w-full h-full object-cover rounded-2xl"
+                className="absolute top-0 w-full object-cover rounded-2xl
+                max-md: h-full "
               />
               {selectedImageUrl === imageUrl && (
-                <div className="relative w-full h-[168px] rounded-2xl bg-white bg-opacity-60">
+                <div className="relative w-full h-full rounded-2xl bg-white bg-opacity-60">
                   <img
                     src={IcCheckTheme}
                     alt="배경화면 선택 아이콘"
@@ -85,6 +89,6 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
         ))}
       </ul>
       {uploadError && <p className="text-red-500 mt-5">{uploadError}</p>}
-    </div>
+    </>
   );
 };

--- a/src/pages/postTheme/components/BackgroundImageList.tsx
+++ b/src/pages/postTheme/components/BackgroundImageList.tsx
@@ -49,10 +49,13 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
   };
 
   return (
-    <div>
-      <ul className="flex gap-x-4">
+    <div className="max-md:grid">
+      <ul className="flex gap-x-4 max-md:grid grid-cols-2 row-span-2 gap-y-4">
         {imageUrls.map((imageUrl, index) => (
-          <li key={index} className="relative w-full h-[168px] rounded-2xl">
+          <li
+            key={index}
+            className="relative w-full h-[154px] rounded-2xl max-md:grid"
+          >
             <input
               type="checkbox"
               id={`img-${index}`}

--- a/src/pages/postTheme/components/BackgroundImageList.tsx
+++ b/src/pages/postTheme/components/BackgroundImageList.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useState, useEffect } from "react";
 import { BackgroundImageListProps } from "../constants/propTypes";
 import useUpdateThemeData from "../hooks/useUpdateThemeData";
-import IcPlusDarkGray from "../assets/icons/ic_plus_darkGray.png";
 import IcCheckTheme from "../assets/icons/ic_check_theme.png";
 
 export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
@@ -15,6 +14,27 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
   const [uploadError, setUploadError] = useState<string | null>(null);
   const updateThemeData = useUpdateThemeData(setThemeData);
 
+  useEffect(() => {
+    const fetchImageUrls = async () => {
+      try {
+        const backgroundImageUrl =
+          "https://rolling-api.vercel.app/background-images/";
+        const response = await fetch(backgroundImageUrl);
+        const data = await response.json();
+
+        if (data && data.imageUrls && data.imageUrls.length > 0) {
+          setImageUrls(data.imageUrls);
+          // 첫 번째 이미지 URL 선택
+          setSelectedImageUrl(data.imageUrls[0]);
+        }
+      } catch (error) {
+        console.error("backgroundImageUrl 패치 실패:", error);
+      }
+    };
+
+    fetchImageUrls();
+  }, []);
+
   // selectedImageUrl이 변경될 때마다 themeData 업데이트
   useEffect(() => {
     if (selectedImageUrl) {
@@ -22,72 +42,15 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
     }
   }, [selectedImageUrl, setThemeData]);
 
-  // 업로드할 이미지 갯수 3개 제한
-  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (imageUrls.length >= 3) {
-      setUploadError("이미지는 최대 3개까지만 업로드할 수 있습니다.");
-      return;
-    }
-
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        // 업로드 에러 처리
-        if (typeof reader.result === "string") {
-          // if (reader.result.length > 300) {
-          //   setUploadError(
-          //     "이미지 URL이 너무 깁니다. 300자 이하의 이미지를 업로드해주세요."
-          //   );
-          //   return;
-          // }
-          setImageUrls((prevImages) => [
-            ...prevImages,
-            reader.result as string,
-          ]);
-          setUploadError(null);
-        }
-      };
-      reader.onerror = () => {
-        setUploadError("이미지 업로드 중 오류가 발생했습니다.");
-      };
-      reader.readAsDataURL(file);
-    }
-  };
-
   // 이미지 선택 처리
   const handleImageSelect = (imageUrl: string) => {
     setSelectedImageUrl(imageUrl);
     handleOptionClick("backgroundImageURL", imageUrl);
   };
 
-  // 이미지 삭제 처리
-  const handleImageDelete = (imageUrl: string) => {
-    setImageUrls((prevImages) => prevImages.filter((url) => url !== imageUrl));
-    if (selectedImageUrl === imageUrl) {
-      setSelectedImageUrl("");
-      updateThemeData("backgroundImageURL", null);
-    }
-  };
-
   return (
     <div>
       <ul className="flex gap-x-4">
-        <label className="w-[168px] h-[168px] rounded-2xl bg-gray-100 cursor-pointer">
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleImageUpload}
-            className="hidden"
-          />
-          <div className="relative w-[168px] h-[168px]">
-            <img
-              src={IcPlusDarkGray}
-              alt="배경화면 추가 아이콘"
-              className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-12 h-12"
-            />
-          </div>
-        </label>
         {imageUrls.map((imageUrl, index) => (
           <li key={index} className="relative">
             <input
@@ -108,12 +71,6 @@ export const BackgroundImageList: React.FC<BackgroundImageListProps> = ({
                 alt={`background ${index}`}
                 className="absolute top-0 w-full h-full rounded-2xl"
               />
-              <button
-                onClick={() => handleImageDelete(imageUrl)}
-                className="absolute top-2 right-2 bg-violet-700 text-sm font-semibold text-white py-0.5 px-2 rounded-full"
-              >
-                X
-              </button>
               {selectedImageUrl === imageUrl && (
                 <img
                   src={IcCheckTheme}

--- a/src/pages/postTheme/components/Form.tsx
+++ b/src/pages/postTheme/components/Form.tsx
@@ -33,7 +33,7 @@ const Form: React.FC<FormProps> = ({
   };
 
   return (
-    <form className="flex flex-col mt-32 m-auto gap-12 max-w-3xl">
+    <form className="flex flex-col grow items-center mt-32 m-auto gap-12 max-w-3xl max-[1248px]:mx-6">
       {React.Children.map(children, (child) => {
         if (React.isValidElement(child)) {
           const childProps = {
@@ -50,7 +50,7 @@ const Form: React.FC<FormProps> = ({
         type="button"
         onClick={onButtonClick}
         disabled={isDisabled || isSubmitting}
-        className={`mt-6 h-[52px] rounded-xl text-white text-lg
+        className={`flex w-full justify-center items-center mt-6 h-[52px] rounded-xl text-white text-lg
          ${isDisabled ? "bg-gray-400" : "bg-violet-500"}`}
       >
         생성하기

--- a/src/pages/postTheme/components/Form.tsx
+++ b/src/pages/postTheme/components/Form.tsx
@@ -50,7 +50,7 @@ const Form: React.FC<FormProps> = ({
         type="button"
         onClick={onButtonClick}
         disabled={isDisabled || isSubmitting}
-        className={`flex w-full justify-center items-center mt-6 h-[52px] rounded-xl text-white text-lg
+        className={`flex w-full justify-center items-center my-6 py-3.5 h-[52px] rounded-xl text-white text-lg
          ${isDisabled ? "bg-gray-400" : "bg-violet-500"}`}
       >
         생성하기

--- a/src/pages/postTheme/components/ReceiverInput.tsx
+++ b/src/pages/postTheme/components/ReceiverInput.tsx
@@ -18,7 +18,7 @@ const ReceiverInput: React.FC<ReceiverInputProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-3 w-full">
+    <section className="flex flex-col gap-3 w-full">
       <label className="font-bold text-2xl">To.</label>
       <input
         type="text"
@@ -30,7 +30,7 @@ const ReceiverInput: React.FC<ReceiverInputProps> = ({
         className="py-3 px-4 rounded-lg outline outline-1 outline-gray-300 text-gray-500 placeholder-gray-500"
       />
       {error && <span className="text-red-500">{error}</span>}
-    </div>
+    </section>
   );
 };
 

--- a/src/pages/postTheme/components/ReceiverInput.tsx
+++ b/src/pages/postTheme/components/ReceiverInput.tsx
@@ -27,7 +27,7 @@ const ReceiverInput: React.FC<ReceiverInputProps> = ({
         onChange={handleChange}
         onBlur={handleBlur}
         placeholder="받는 사람 이름을 입력해주세요"
-        className="py-3 px-4 rounded-lg outline outline-1 outline-gray-300 text-gray-500"
+        className="py-3 px-4 rounded-lg outline outline-1 outline-gray-300 text-gray-500 placeholder-gray-500"
       />
       {error && <span className="text-red-500">{error}</span>}
     </div>

--- a/src/pages/postTheme/components/ReceiverInput.tsx
+++ b/src/pages/postTheme/components/ReceiverInput.tsx
@@ -18,7 +18,7 @@ const ReceiverInput: React.FC<ReceiverInputProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 w-full">
       <label className="font-bold text-2xl">To.</label>
       <input
         type="text"

--- a/src/pages/postTheme/components/ThemeSelection.tsx
+++ b/src/pages/postTheme/components/ThemeSelection.tsx
@@ -48,8 +48,6 @@ const ThemeSelection: React.FC<ThemeSelectionProps> = ({
 
   // 선택된 테마 타입과 옵션을 관리하는 이벤트 핸들러
   const handleOptionClick = (optionType: string, value: string) => {
-    console.log(`Option clicked: ${optionType} - ${value}`);
-    console.log(selectedImageUrl);
     if (optionType === "backgroundColor") {
       setSelectedColor(value);
       updateThemeData("backgroundColor", value);
@@ -60,7 +58,7 @@ const ThemeSelection: React.FC<ThemeSelectionProps> = ({
   };
 
   return (
-    <section className="flex flex-col gap-12">
+    <section className="flex flex-col gap-12 w-full">
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <p className="font-bold text-2xl">배경화면을 선택해 주세요.</p>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,11 @@ module.exports = {
       },
     },
   },
+  corePlugins: {
+    aspectRatio: false,
+  },
   plugins: [
+    require("@tailwindcss/aspect-ratio"),
     {
       tailwindcss: {},
       autoprefixer: {},


### PR DESCRIPTION
##  변경 사항

> ### design
> 
> - 태블릿, 모바일 사이즈 미디어쿼리 적용
> - 선택된 이미지의 불투명도 조절
> 
> ### chore
> - aspect-ratio 설치
>
> ### refactor
> - 시맨틱 태그 추가, div -> ul 또는 section

<br>

##  세부 설명
- '이미지' 메뉴에서 '이미지' 클릭 시 이미지가 투명해지도록 변경했습니다.
- 이미지 종횡비 조절을 위해  aspect-ratio를 적용했습니다.

<br>

## 스크린샷
![image](https://github.com/user-attachments/assets/1fba5c76-236e-41bf-9885-c03c458bd587)
![SHANA 녹음 2024-07-16 214305](https://github.com/user-attachments/assets/8ce8a13c-f3dd-499b-aecf-a06746b876d2)


<br>


## 비고
- PR을 분리해서 올리기 위해 브랜치를 생성했습니다.
- 추가할 부분, 변경되었으면 하는 부분이 있다면 알려주세요! 