### PR TITLE
[2024.07.18] list: 최신 sender 3명의 프로필 이미지 보여주는 기능 추가

### DIFF
--- a/src/pages/ListPage/components/BestRecipientCardList.tsx
+++ b/src/pages/ListPage/components/BestRecipientCardList.tsx
@@ -2,86 +2,91 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import RecipientCard from './RecipientCard';
 
+interface RecentMessage {
+    id: number;
+    sender: string;
+    profileImageURL: string;
+}
+
 interface Recipient {
-  id: string;
-  name: string;
-  recentMessages: string;
-  messageCount: number;
-  topReactions: { emoji: string; count: number }[]; 
-  backgroundColor: string;
-  backgroundImageURL?: string | null; 
+    id: string;
+    name: string;
+    recentMessages: RecentMessage[];
+    topReactions: { emoji: string; count: number }[];
+    backgroundColor: string;
+    backgroundImageURL?: string | null;
 }
 
 interface BestRecipientCardListProps {
-  data: {
-    results: Recipient[];
-  };
+    data: {
+        results: Recipient[];
+    };
 }
 
 const BestRecipientCardList: React.FC<BestRecipientCardListProps> = ({ data }) => {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const cardsToShow = 4; // 한 번에 보여줄 카드 수
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const cardsToShow = 4;
 
-  // 데이터를 메시지 수 기준으로 내림차순 정렬하는 상태 변수
-  const [sortedData, setSortedData] = useState<Recipient[]>([]);
+    // 데이터를 메시지 수 기준으로 내림차순 정렬하는 상태 변수
+    const [sortedData, setSortedData] = useState<Recipient[]>([]);
 
-  // 데이터가 변경될 때마다 정렬하여 sortedData 업데이트
-  useEffect(() => {
-    const sortedRecipients = [...data.results].sort(
-      (a, b) => b.recentMessages.length - a.recentMessages.length
-    );
-    setSortedData(sortedRecipients);
-  }, [data.results]);
+    // 데이터가 변경될 때마다 정렬하여 sortedData 업데이트
+    useEffect(() => {
+        const sortedRecipients = [...data.results].sort(
+            (a, b) => b.recentMessages.length - a.recentMessages.length
+        );
+        setSortedData(sortedRecipients);
+    }, [data.results]);
 
-  const totalCards = sortedData.length;
-  const maxIndex = Math.ceil(totalCards / cardsToShow) - 1;
+    const totalCards = sortedData.length;
+    const maxIndex = Math.ceil(totalCards / cardsToShow) - 1;
 
-  const prevSlide = () => {
-    setCurrentIndex((prev) => Math.max(prev - 1, 0));
-  };
+    const prevSlide = () => {
+        setCurrentIndex((prev) => Math.max(prev - 1, 0));
+    };
 
-  const nextSlide = () => {
-    setCurrentIndex((prev) => Math.min(prev + 1, maxIndex));
-  };
+    const nextSlide = () => {
+        setCurrentIndex((prev) => Math.min(prev + 1, maxIndex));
+    };
 
-  return (
-    <div className="relative">
-      <button
-        className="rounded-full absolute top-1/2 left-0 transform -translate-y-1/2 bg-white border border-gray-300 px-3 py-1 cursor-pointer z-10"
-        onClick={prevSlide}
-        disabled={currentIndex === 0}
-      >
-        {"<"}
-      </button>
-      <div className="overflow-hidden w-full">
-        <div
-          className="flex transition-transform duration-500"
-          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-        >
-          {sortedData.map((recipient, index) => (
-            <div className="min-w-[25%] box-border p-2" key={recipient.id}>
-              <Link to={`/post/${recipient.id}`}>
-                <RecipientCard
-                  name={recipient.name}
-                  recentMessages={recipient.recentMessages}
-                  topReactions={recipient.topReactions}
-                  backgroundColor={recipient.backgroundColor}
-                  backgroundImageURL={recipient.backgroundImageURL} // 배경 이미지 URL 전달
-                />
-              </Link>
+    return (
+        <div className="relative">
+            <button
+                className="rounded-full absolute top-1/2 left-0 transform -translate-y-1/2 bg-white border border-gray-300 px-3 py-1 cursor-pointer z-10"
+                onClick={prevSlide}
+                disabled={currentIndex === 0}
+            >
+                {"<"}
+            </button>
+            <div className="overflow-hidden w-full">
+                <div
+                    className="flex transition-transform duration-500"
+                    style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+                >
+                    {sortedData.map((recipient, index) => (
+                        <div className="min-w-[25%] box-border p-2" key={recipient.id}>
+                            <Link to={`/post/${recipient.id}`}>
+                                <RecipientCard
+                                    name={recipient.name}
+                                    recentMessages={recipient.recentMessages}
+                                    topReactions={recipient.topReactions}
+                                    backgroundColor={recipient.backgroundColor}
+                                    backgroundImageURL={recipient.backgroundImageURL} // 배경 이미지 URL 전달
+                                />
+                            </Link>
+                        </div>
+                    ))}
+                </div>
             </div>
-          ))}
+            <button
+                className="rounded-full absolute top-1/2 right-0 transform -translate-y-1/2 bg-white border border-gray-300 px-3 py-1 cursor-pointer z-10"
+                onClick={nextSlide}
+                disabled={currentIndex === maxIndex}
+            >
+                {">"}
+            </button>
         </div>
-      </div>
-      <button
-        className="rounded-full absolute top-1/2 right-0 transform -translate-y-1/2 bg-white border border-gray-300 px-3 py-1 cursor-pointer z-10"
-        onClick={nextSlide}
-        disabled={currentIndex === maxIndex}
-      >
-        {">"}
-      </button>
-    </div>
-  );
+    );
 };
 
 export default BestRecipientCardList;

--- a/src/pages/ListPage/components/RecipientCard.tsx
+++ b/src/pages/ListPage/components/RecipientCard.tsx
@@ -2,10 +2,14 @@ import React from "react";
 
 interface RecipientCardProps {
   name: string;
-  recentMessages: string;
+  recentMessages: {
+    id: number;
+    sender: string;
+    profileImageURL: string;
+  }[];
   topReactions: { emoji: string; count: number }[];
   backgroundColor: string;
-  backgroundImageURL?: string | null; // backgroundImageURL이 null일 수 있음을 명시
+  backgroundImageURL?: string | null;
 }
 
 const RecipientCard: React.FC<RecipientCardProps> = ({
@@ -35,35 +39,54 @@ const RecipientCard: React.FC<RecipientCardProps> = ({
       break;
   }
 
-
   const cardStyle: React.CSSProperties = {
     backgroundImage: backgroundImageURL ? `url(${backgroundImageURL})` : undefined,
-    backgroundSize: "cover", 
-    backgroundPosition: "center", 
-  };  
-
-  const bgColorStyle = backgroundImageURL ? "" : bgColorClass;
+    backgroundSize: "cover",
+    backgroundPosition: "center",
+    position: "relative",
+  };
 
   return (
     <div
-      className={`w-[275px] h-[260px] p-4 mb-4 border rounded-[16px] border-solid border-[#0000001A] shadow-md ${bgColorStyle}`}
+      className={`w-[275px] h-[260px] p-4 mb-4 border rounded-[16px] border-solid border-[#0000001A] shadow-md ${bgColorClass}`}
       style={cardStyle}
     >
-      <div className="p-2 rounded-md">
-        <h2 className="font-pretendard text-[24px] font-bold leading-[36px] tracking-[-0.01em] text-left">
-          To. {name}
-        </h2>
-        <p className="font-pretendard text-[16px] font-bold leading-[26px] tracking-[-0.01em] text-left inline">
-          {recentMessages.length}
-        </p>
-        <span className="font-pretendard text-[16px] font-normal leading-[26px] tracking-[-0.01em] text-left inline">
-          명이 작성했어요!
-        </span>
+      <div className="p-2 rounded-md relative flex flex-col justify-between h-full">
+        <div>
+          <h2 className="font-pretendard text-[24px] font-bold leading-[36px] tracking-[-0.01em] text-left">
+            To. {name}
+          </h2>
+          <p className="font-pretendard text-[16px] font-bold leading-[26px] tracking-[-0.01em] text-left inline">
+            {recentMessages.length}
+          </p>
+          <span className="font-pretendard text-[16px] font-normal leading-[26px] tracking-[-0.01em] text-left inline">
+            명이 작성했어요!
+          </span>
+          <div className="mt-2 flex flex-wrap gap-[-30px] relative">
+            {recentMessages.map((message, index) => (
+              <img
+                key={message.id}
+                src={message.profileImageURL}
+                alt={message.sender}
+                className="w-7 h-7 object-cover rounded-full border-2 border-white"
+                style={{
+                  position: "absolute",
+                  left: `${index * 20}px`,
+                  zIndex: recentMessages.length - index, // 인덱스에 따라 z-index 설정
+                }}
+              />
+            ))}
+          </div>
+        </div>
         <div className="mt-2">
-          <ul className="flex flex-wrap gap-2">
+          <ul className="flex flex-wrap gap-2 border-t border-solid border-[#0000001F] w-227 pt-4">
             {topReactions.map((reaction, index) => (
-              <li key={index} className="flex items-center gap-1 bg-[#0000008A] px-2 py-1 rounded-full">
-                {reaction.emoji} 
+              <li 
+                key={index}
+                className="flex items-center gap-1 bg-[#0000008A] px-2 py-1 rounded-full"
+                style={{ alignSelf: "flex-end" }} // 이모지 카운트를 카드 하단에 위치시키기 위해
+              >
+                {reaction.emoji}
                 <span className="font-pretendard text-16 font-normal leading-20 text-white">
                   {reaction.count}
                 </span>

--- a/src/pages/ListPage/components/RecipientCardList.tsx
+++ b/src/pages/ListPage/components/RecipientCardList.tsx
@@ -2,13 +2,19 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import RecipientCard from './RecipientCard';
 
+interface RecentMessage {
+    id: number;
+    sender: string;
+    profileImageURL: string;
+}
+
 interface Recipient {
     id: string;
     name: string;
-    recentMessages: string;
+    recentMessages: RecentMessage[];
     topReactions: { emoji: string; count: number }[];
     backgroundColor: string;
-    backgroundImageURL?: string | null; // backgroundImageURL이 null일 수 있음을 명시
+    backgroundImageURL?: string | null;
 }
 
 interface RecipientCardListProps {


### PR DESCRIPTION
![스크린샷 2024-07-18 001335](https://github.com/user-attachments/assets/7fd2e403-e35a-401c-9969-8a7b56e62f3a)
## 변경사항
-최신 sender 3명의 프로필 이미지 보여주는 기능 추가했습니다.
-이모지 카운터를 카드의 아래에 배치했습니다.
-이모지 카운터의 위에 가느다란 실선을 추가했습니다.

## 비고
- 이모지 카운터에 아무 이모지도 없으면 위에 가느다란 실선이 안보이게 하는 것이 좋을까요? (스크린샷 속 To.김철수, To. sdfsdf 카드 부분 참조)