### PR TITLE
[2024.07.20] List Fix: IOS에서 카드 요소가 카드 밖으로 삐져나오는 현상 수정

### DIFF
--- a/src/pages/ListPage/components/RecipientCard.tsx
+++ b/src/pages/ListPage/components/RecipientCard.tsx
@@ -42,7 +42,9 @@ const RecipientCard: React.FC<RecipientCardProps> = ({
     }
 
     const cardStyle: React.CSSProperties = {
-        backgroundImage: backgroundImageURL ? `url(${backgroundImageURL})` : undefined,
+        backgroundImage: backgroundImageURL
+            ? `linear-gradient(rgba(0, 0, 0, 0.54), rgba(0, 0, 0, 0.54)), url(${backgroundImageURL})`
+            : undefined,
         backgroundSize: "cover",
         backgroundPosition: "center",
         position: "relative",
@@ -52,7 +54,7 @@ const RecipientCard: React.FC<RecipientCardProps> = ({
 
     return (
         <div
-            className={`w-[275px] h-[260px] p-4 mb-4 border rounded-[16px] border-solid border-[#0000001A] shadow-md ${bgColorClass} relative overflow-hidden transition-all duration-300 ease-in-out`}
+            className={` absolute w-[275px] h-[260px] p-4 mb-4 border rounded-[16px] border-solid border-[#0000001A] shadow-md ${bgColorClass} relative overflow-hidden transition-all duration-300 ease-in-out`}
             style={{
                 ...cardStyle,
                 transform: isHovered ? 'scale(1.05)' : 'scale(1)',
@@ -61,51 +63,74 @@ const RecipientCard: React.FC<RecipientCardProps> = ({
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
-            {backgroundColor === "purple" && backgroundImageURL === null &&(
-                <div 
-                    className="absolute right-0 bottom-0 w-[336px] h-[169px] rounded-tl-[90.5px] overflow-hidden"
-                    style={{
-                        background: 'rgba(220, 185, 255, 0.4)',
-                        transform: 'translate(55%, 30%)',
-                    }}
-                />
-            )}
+        {backgroundColor === "purple" && !backgroundImageURL && (<div
+        style={{ width: '142px', height: '142px', overflow: 'hidden', borderBottomRightRadius: '16px' }}
+        className="absolute right-0 bottom-0"
+    >
+            <svg
+                width="142"
+                height="142"
+                viewBox="0 0 142 142"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="absolute right-0 bottom-0"
+            >
+                <g clipPath="url(#clip0_23083_1868)">
+                    <rect
+                        y="6"
+                        width="336"
+                        height="169"
+                        rx="84.5"
+                        fill="#DCB9FF"
+                        fillOpacity="0.4"
+                    />
+                </g>
+                <defs>
+                    <clipPath id="clip0_23083_1868">
+                        <rect width="142" height="142" fill="white" />
+                    </clipPath>
+                </defs>
+            </svg></div>
+        )}
             {backgroundColor === "beige" && backgroundImageURL === null &&(
-                <div 
-                    className="absolute right-0 bottom-0 w-[332px] h-[169px] rounded-tl-[51px] overflow-hidden"
-                    style={{
-                        background: 'rgba(255, 211, 130, 0.7)',
-                        transform: 'translate(60%, 30%)',
-                    }}
-                />
+                <div
+        style={{ width: '142px', height: '142px', overflow: 'hidden', borderBottomRightRadius: '16px' }}
+        className="absolute right-0 bottom-0"
+    >
+            <svg width="142" height="142" viewBox="0 0 142 142" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 57C21 28.8335 43.8335 6 72 6H302C330.167 6 353 28.8335 353 57V273C353 301.167 330.167 324 302 324H72C43.8335 324 21 301.167 21 273V57Z" fill="#FFD382" fill-opacity="0.7"/>
+</svg>
+</div>
             )}
             {backgroundColor === "blue" && backgroundImageURL === null &&(
-                <svg
-                    className="absolute"
-                    style={{ transform: 'translate(85%, 70%)' }}
-                    width="142"
-                    height="142"
-                    viewBox="0 0 142 142"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                    <path
-                        d="M74.4299 16.6978C88.1712 -5.00283 119.829 -5.00284 133.57 16.6978L202.482 125.526C217.239 148.829 200.495 179.25 172.912 179.25H35.0878C7.5049 179.25 -9.23877 148.829 5.51768 125.526L74.4299 16.6978Z"
-                        fill="#9DDDFF"
-                    />
-                </svg>
+                <div
+                style={{ width: '142px', height: '142px', overflow: 'hidden', borderBottomRightRadius: '16px' }}
+                className="absolute right-0 bottom-0"
+            >
+                    <svg width="142" height="142" viewBox="0 0 142 142" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M74.4299 16.6978C88.1712 -5.00283 119.829 -5.00284 133.57 16.6978L202.482 125.526C217.239 148.829 200.495 179.25 172.912 179.25H35.0878C7.5049 179.25 -9.23877 148.829 5.51768 125.526L74.4299 16.6978Z" fill="#9DDDFF"/>
+</svg>
+
+        </div>
             )}
             {backgroundColor === "green" && backgroundImageURL === null &&(
-                <div 
-                    className="absolute right-0 bottom-0 w-[336px] h-[169px] rounded-tl-[90.5px] overflow-hidden"
-                    style={{
-                        background: 'rgba(155, 226, 130, 0.3)',
-                        transform: 'translate(55%, 30%)',
-                    }}
-                />
-            )}
-            {backgroundImageURL && (
-                <div className="absolute inset-0 bg-black bg-opacity-50"></div>
+                                <div
+                                style={{ width: '142px', height: '142px', overflow: 'hidden', borderBottomRightRadius: '16px' }}
+                                className="absolute right-0 bottom-0"
+                            >
+                                    <svg width="142" height="142" viewBox="0 0 142 142" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_23083_4684)">
+<rect y="6" width="336" height="169" rx="84.5" fill="#9BE282" fill-opacity="0.3"/>
+</g>
+<defs>
+<clipPath id="clip0_23083_4684">
+<rect width="142" height="142" fill="white"/>
+</clipPath>
+</defs>
+</svg>
+
+                
+                        </div>
             )}
             <div className={`p-2 rounded-md relative flex flex-col justify-between h-full z-10 ${textColorClass} transition-opacity duration-300 ${isHovered ? 'opacity-100' : 'opacity-90'}`}>
                 <div>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/e7d59b6d-9f5c-4fec-942d-23d5c74cf66c" width="30%" /><img src="https://github.com/user-attachments/assets/ff904fbe-3fb5-4577-80b7-b458998619f9" width="30%" />
<img src="https://github.com/user-attachments/assets/a6f1ba40-9aeb-43b3-9663-cbda4a9d5787" width="50%" /><img src="https://github.com/user-attachments/assets/29e5299e-ce1c-449d-bd00-012a1ab6e423" width="50%" />


> ### 전->후

## 수정사항
-IOS에서 overflow hidden이 적용되지 않아 카드 요소가 카드 밖으로 삐져나오는 현상을 수정했습니다.

## 비고
-분명 데스크톱, 안드로이드, 크롬 개발자 도구에서는 잘 작동되는 모습을 확인했는데 아이폰, 아이패드로 확인하니 이런 생각치도 못한 버그가 나타나는 걸 보니 크로스브라우징 테스트가 중요할 것 같습니다. 